### PR TITLE
add details on default usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ export default {
 - keydown (as default) 
 - keyup
 
+If you only want one handler you should use `keydown`. 
+
 ## Key Combination
 
 Use one or more of following keys to fire your hotkeys.


### PR DESCRIPTION
because if I use it like this
```
      enter: {
          keyup: this.doSomeLogicOnPressEnter,
        }
```
see, only keyup and no keydown - I get error