### PR TITLE
Add ability to only import the directive #26

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,26 @@
 import { bindEvent, unbindEvent } from './main'
 
-export default {
-  install (Vue, alias = {}) {
-    Vue.directive('hotkey', {
-      bind (el, binding) {
+const buildDirective = function (alias = {}) {
+  return {
+    bind (el, binding) {
+      bindEvent(el, binding, alias)
+    },
+    componentUpdated (el, binding) {
+      if (binding.value !== binding.oldValue) {
+        unbindEvent(el)
         bindEvent(el, binding, alias)
-      },
-      componentUpdated (el, binding) {
-        if (binding.value !== binding.oldValue) {
-          unbindEvent(el)
-          bindEvent(el, binding, alias)
-        }
-      },
-      unbind: unbindEvent
-    })
+      }
+    },
+    unbind: unbindEvent
   }
 }
+
+const plugin = {
+  install (Vue, alias = {}) {
+    Vue.directive('hotkey', buildDirective(alias))
+  },
+
+  directive: buildDirective()
+}
+
+export default plugin


### PR DESCRIPTION
Hello @Dafrok :)

I just added the ability to import only the directive in your package (in reference to #26).

I mainly followed the code from `v-click-outside` (https://github.com/ndelvalle/v-click-outside/blob/master/src/index.js).

Feel free to merge this. For an example about how to use it: https://github.com/growthbunker/vuedarkmode/blob/master/src/components/fields/FieldSelect.vue.