### PR TITLE
Compile when installing from Github.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:docs": "vue-cli-service build ./src/docs/main.js --dest docs",
     "build:docs:dev": "npm run build:docs -- --mode development",
     "dev": "vue-cli-service serve",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "test": "vue-cli-service test:unit"
   },
   "main": "dist/v-hotkey.common.js",


### PR DESCRIPTION
Using `prepare` instead of `prepublishOnly` enable to build when installing from github, making eg. `npm install https://github.com/Dafrok/v-hotkey` work out of the box. Unless I misread the documentation, it will still be run before publishing.