### PR TITLE
Set forbidden nodes as plugin option

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,3 @@
-
-const FORBIDDEN_NODES = ['INPUT', 'TEXTAREA', 'SELECT']
-
 /**
  *
  * @param {Object} a
@@ -53,7 +50,7 @@ const getHotkeyCallback = (keyMap, keyCode, eventKeyModifiers) => {
  * @param {Array} keyMap
  * @param {Object} modifiers Vue event modifiers
  */
-export const assignKeyHandler = (e, keyMap, modifiers) => {
+export const assignKeyHandler = (e, keyMap, modifiers, forbiddenNodes) => {
   const { keyCode, ctrlKey, altKey, shiftKey, metaKey } = e
   const eventKeyModifiers = { ctrlKey, altKey, shiftKey, metaKey }
 
@@ -67,7 +64,7 @@ export const assignKeyHandler = (e, keyMap, modifiers) => {
 
   const { nodeName, isContentEditable } = document.activeElement
   if (isContentEditable) return
-  if (FORBIDDEN_NODES.includes(nodeName)) return
+  if (forbiddenNodes.includes(nodeName)) return
 
   const callback = getHotkeyCallback(keyMap, keyCode, eventKeyModifiers)
   if (!callback) return e

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,5 @@
+export const DEFAULT_FORBIDDEN_NODES = ['INPUT', 'TEXTAREA', 'SELECT']
+
 /**
  *
  * @param {Object} a
@@ -50,7 +52,7 @@ const getHotkeyCallback = (keyMap, keyCode, eventKeyModifiers) => {
  * @param {Array} keyMap
  * @param {Object} modifiers Vue event modifiers
  */
-export const assignKeyHandler = (e, keyMap, modifiers, forbiddenNodes) => {
+export const assignKeyHandler = (e, keyMap, modifiers, forbiddenNodes = DEFAULT_FORBIDDEN_NODES) => {
   const { keyCode, ctrlKey, altKey, shiftKey, metaKey } = e
   const eventKeyModifiers = { ctrlKey, altKey, shiftKey, metaKey }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
+import { DEFAULT_FORBIDDEN_NODES } from './helpers'
 import { bindEvent, unbindEvent } from './main'
 
-const DEFAULT_FORBIDDEN_NODES = ['INPUT', 'TEXTAREA', 'SELECT']
-
-const buildDirective = function (alias = {}, forbiddenNodes = DEFAULT_FORBIDDEN_NODES) {
+const buildDirective = function (alias, forbiddenNodes) {
   return {
     bind (el, binding) {
       bindEvent(el, binding, alias, forbiddenNodes)

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
 import { bindEvent, unbindEvent } from './main'
 
-const buildDirective = function (alias = {}) {
+const DEFAULT_FORBIDDEN_NODES = ['INPUT', 'TEXTAREA', 'SELECT']
+
+const buildDirective = function (alias = {}, forbiddenNodes = DEFAULT_FORBIDDEN_NODES) {
   return {
     bind (el, binding) {
-      bindEvent(el, binding, alias)
+      bindEvent(el, binding, alias, forbiddenNodes)
     },
     componentUpdated (el, binding) {
       if (binding.value !== binding.oldValue) {
         unbindEvent(el)
-        bindEvent(el, binding, alias)
+        bindEvent(el, binding, alias, forbiddenNodes)
       }
     },
     unbind: unbindEvent
@@ -16,8 +18,8 @@ const buildDirective = function (alias = {}) {
 }
 
 const plugin = {
-  install (Vue, alias = {}) {
-    Vue.directive('hotkey', buildDirective(alias))
+  install (Vue, alias = {}, forbidden_nodes = DEFAULT_FORBIDDEN_NODES) {
+    Vue.directive('hotkey', buildDirective(alias, forbidden_nodes))
   },
 
   directive: buildDirective()

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,9 @@ const buildDirective = function (alias = {}, forbiddenNodes = DEFAULT_FORBIDDEN_
 }
 
 const plugin = {
-  install (Vue, alias = {}, forbidden_nodes = DEFAULT_FORBIDDEN_NODES) {
-    Vue.directive('hotkey', buildDirective(alias, forbidden_nodes))
+  install (Vue, options = {}) {
+    const { alias = {}, forbiddenNodes = DEFAULT_FORBIDDEN_NODES } = options;
+    Vue.directive('hotkey', buildDirective(alias, forbiddenNodes))
   },
 
   directive: buildDirective()

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,9 @@ import { assignKeyHandler } from './helpers'
  * @param {Object} bindings
  * @param {Object} alias
  */
-function bindEvent (el, { value, modifiers }, alias) {
+function bindEvent (el, { value, modifiers }, alias, forbiddenNodes) {
   el._keyMap = getKeyMap(value, alias)
-  el._keyHandler = e => assignKeyHandler(e, el._keyMap, modifiers)
+  el._keyHandler = e => assignKeyHandler(e, el._keyMap, modifiers, forbiddenNodes)
 
   document.addEventListener('keydown', el._keyHandler)
   document.addEventListener('keyup', el._keyHandler)

--- a/tests/unit/FooWithInput.vue
+++ b/tests/unit/FooWithInput.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <input />
+    <div
+      v-hotkey="{ enter: show, esc: hide }"
+      class="hotkey"
+    >
+      Toggle
+    </div>
+    <div
+      v-if="visible"
+      class="visible"
+    >
+      Hello hotkey
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data: () => ({ visible: false }),
+  methods: {
+    show () {
+      this.visible = true
+    },
+    hide () {
+      this.visible = false
+    }
+  }
+}
+</script>

--- a/tests/unit/directive.spec.js
+++ b/tests/unit/directive.spec.js
@@ -1,6 +1,7 @@
 import { mount, createLocalVue } from '@vue/test-utils'
 import hotkeyDirective from '../../src/index'
 import Foo from './Foo.vue'
+import FooWithInput from './FooWithInput.vue'
 
 const localVue = createLocalVue()
 localVue.use(hotkeyDirective)
@@ -31,4 +32,34 @@ describe('Hotkey works', () => {
     div = wrapper.find('.visible')
     expect(div.exists()).toBe(false)
   })
+
+it('directive doesnt work on input node', async () => {
+    const wrapper = mount(FooWithInput, {
+      localVue,
+      attachToDocument: true
+    })
+
+    wrapper.find('input').element.focus()
+    wrapper.trigger('keydown.enter')
+    let div = wrapper.find('.visible')
+    expect(div.exists()).toBe(false)
+  });
+
+it('directive works on all nodes (forbiddenNodes: [])', async () => {
+    const localVue = createLocalVue()
+    localVue.use(hotkeyDirective, { forbiddenNodes: [] })
+    
+    const wrapper = mount(FooWithInput, {
+      localVue,
+      attachToDocument: true
+    })
+
+    wrapper.find('input').element.focus()
+    wrapper.trigger('keydown.enter')
+    let div = wrapper.find('.visible')
+    expect(div.exists()).toBe(true)
+    wrapper.trigger('keydown.esc')
+    div = wrapper.find('.visible')
+    expect(div.exists()).toBe(false)
+  });
 })

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -51,7 +51,7 @@ describe('helper functions', () => {
       }
     }]
 
-    assignKeyHandler(e, keyMap, {}, [])
+    assignKeyHandler(e, keyMap, {})
 
     expect(mockFn).toHaveBeenCalled()
   })
@@ -81,7 +81,7 @@ describe('helper functions', () => {
       }
     }]
 
-    assignKeyHandler(e, keyMap, {}, [])
+    assignKeyHandler(e, keyMap, {})
 
     expect(mockFn).not.toHaveBeenCalled()
   })
@@ -98,7 +98,7 @@ describe('helper functions', () => {
       preventDefault: mockFn
     }
 
-    assignKeyHandler(e, [], { prevent: true }, [])
+    assignKeyHandler(e, [], { prevent: true })
 
     expect(mockFn).toHaveBeenCalled()
   })
@@ -115,7 +115,7 @@ describe('helper functions', () => {
       stopPropagation: mockFn
     }
 
-    assignKeyHandler(e, [], { stop: true }, [])
+    assignKeyHandler(e, [], { stop: true })
     expect(mockFn).toHaveBeenCalled()
   })
 
@@ -133,7 +133,7 @@ describe('helper functions', () => {
 
     document.activeElement.isContentEditable = true
 
-    assignKeyHandler(e, [], {}, [])
+    assignKeyHandler(e, [], {})
 
     expect(mockFn).not.toHaveBeenCalled()
   })
@@ -159,7 +159,7 @@ describe('helper functions', () => {
     node.focus()
     document.activeElement.isContentEditable = false
 
-    assignKeyHandler(e, [], {}, ['INPUT'])
+    assignKeyHandler(e, [], {})
 
     expect(mockFn).not.toHaveBeenCalled()
   })

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -51,7 +51,7 @@ describe('helper functions', () => {
       }
     }]
 
-    assignKeyHandler(e, keyMap, {})
+    assignKeyHandler(e, keyMap, {}, [])
 
     expect(mockFn).toHaveBeenCalled()
   })
@@ -81,7 +81,7 @@ describe('helper functions', () => {
       }
     }]
 
-    assignKeyHandler(e, keyMap, {})
+    assignKeyHandler(e, keyMap, {}, [])
 
     expect(mockFn).not.toHaveBeenCalled()
   })
@@ -98,7 +98,7 @@ describe('helper functions', () => {
       preventDefault: mockFn
     }
 
-    assignKeyHandler(e, [], { prevent: true })
+    assignKeyHandler(e, [], { prevent: true }, [])
 
     expect(mockFn).toHaveBeenCalled()
   })
@@ -115,7 +115,7 @@ describe('helper functions', () => {
       stopPropagation: mockFn
     }
 
-    assignKeyHandler(e, [], { stop: true })
+    assignKeyHandler(e, [], { stop: true }, [])
     expect(mockFn).toHaveBeenCalled()
   })
 
@@ -133,7 +133,7 @@ describe('helper functions', () => {
 
     document.activeElement.isContentEditable = true
 
-    assignKeyHandler(e, [], {})
+    assignKeyHandler(e, [], {}, [])
 
     expect(mockFn).not.toHaveBeenCalled()
   })
@@ -159,7 +159,7 @@ describe('helper functions', () => {
     node.focus()
     document.activeElement.isContentEditable = false
 
-    assignKeyHandler(e, [], {})
+    assignKeyHandler(e, [], {}, ['INPUT'])
 
     expect(mockFn).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
- In addition to `alias` object, `forbiddenNodes` are added as plugin option
- This is BREAKING CHANGE since it modifies the API of the plugin