### PR TITLE
Adding prop to execute event even on forbidden inputs

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -66,11 +66,11 @@ export const assignKeyHandler = (e, keyMap, modifiers) => {
   }
 
   const { nodeName, isContentEditable } = document.activeElement
-  const callback = getHotkeyCallback(keyMap, keyCode, eventKeyModifiers);
+  const callback = getHotkeyCallback(keyMap, keyCode, eventKeyModifiers)
 
-  if (!callback) return e;
-  if (isContentEditable) return;
-  if (FORBIDDEN_NODES.includes(nodeName) && !callback.executeInForbiddenNode) return;
+  if (!callback) return e
+  if (isContentEditable) return
+  if (FORBIDDEN_NODES.includes(nodeName) && !callback.executeInForbiddenNode) return
 
   e.preventDefault()
   callback[e.type](e)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -66,11 +66,12 @@ export const assignKeyHandler = (e, keyMap, modifiers) => {
   }
 
   const { nodeName, isContentEditable } = document.activeElement
-  if (isContentEditable) return
-  if (FORBIDDEN_NODES.includes(nodeName)) return
+  const callback = getHotkeyCallback(keyMap, keyCode, eventKeyModifiers);
 
-  const callback = getHotkeyCallback(keyMap, keyCode, eventKeyModifiers)
-  if (!callback) return e
+  if (!callback) return e;
+  if (isContentEditable) return;
+  if (FORBIDDEN_NODES.includes(nodeName) && !callback.executeInForbiddenNode) return;
+
   e.preventDefault()
   callback[e.type](e)
 }

--- a/src/keycodes/index.js
+++ b/src/keycodes/index.js
@@ -29,10 +29,11 @@ export const getKeyMap = (combinations, alias) => {
   const result = []
 
   Object.keys(combinations).forEach(combination => {
-    const { keyup, keydown } = combinations[combination]
+    const { keyup, keydown, executeInForbiddenNode } = combinations[combination]
     const callback = {
       keydown: keydown || (keyup ? noop : combinations[combination]),
-      keyup: keyup || noop
+      keyup: keyup || noop,
+      executeInForbiddenNode: executeInForbiddenNode||false
     }
     const keys = splitCombination(combination)
     const { code, modifiers } = resolveCodesAndModifiers(keys, alias)

--- a/tests/unit/Bar.vue
+++ b/tests/unit/Bar.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <input
+      id="text"
+      v-hotkey="{enter: {keydown: toggle, executeInForbiddenNode: true }}"
+      class="text"
+      type="text"
+      autofocus
+    >
+    <div
+      v-if="visible"
+      class="visible"
+    >
+      Enter Pressed
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Bar',
+  data: () => ({ visible: false }),
+  methods: {
+    toggle () {
+      this.visible = !this.visible
+    }
+  }
+}
+</script>

--- a/tests/unit/directive.spec.js
+++ b/tests/unit/directive.spec.js
@@ -1,6 +1,7 @@
 import { mount, createLocalVue } from '@vue/test-utils'
 import hotkeyDirective from '../../src/index'
 import Foo from './Foo.vue'
+import Bar from './Bar.vue'
 
 const localVue = createLocalVue()
 localVue.use(hotkeyDirective)
@@ -28,6 +29,22 @@ describe('Hotkey works', () => {
     let div = wrapper.find('.visible')
     expect(div.exists()).toBe(true)
     wrapper.trigger('keydown.esc')
+    div = wrapper.find('.visible')
+    expect(div.exists()).toBe(false)
+  })
+
+  it('toggle input on tab keydown', async () => {
+    const wrapper = mount(Bar, {
+      localVue,
+      attachToDocument: true
+    })
+    const input = wrapper.find('#text')
+    let div = wrapper.find('.visible')
+    expect(div.exists()).toBe(false)
+    input.trigger('keydown.enter')
+    div = wrapper.find('.visible')
+    expect(div.exists()).toBe(true)
+    input.trigger('keydown.enter')
     div = wrapper.find('.visible')
     expect(div.exists()).toBe(false)
   })

--- a/tests/unit/directive.spec.js
+++ b/tests/unit/directive.spec.js
@@ -33,7 +33,7 @@ describe('Hotkey works', () => {
     expect(div.exists()).toBe(false)
   })
 
-  it('toggle input on tab keydown', async () => {
+  it('toggle input on enter keydown', async () => {
     const wrapper = mount(Bar, {
       localVue,
       attachToDocument: true


### PR DESCRIPTION
Adding support  to property on object for a shortcut to execute the event even on forbidden inputs (executeInForbiddenNode). By default, this value by default is false