### PR TITLE
Fix SSR problem

### DIFF
--- a/src/keycodes/index.js
+++ b/src/keycodes/index.js
@@ -10,13 +10,17 @@ const defaultModifiers = {
   metaKey: false
 }
 
+function isApplePlatform() {
+  return typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
 const alternativeKeyNames = {
   option: 'alt',
   command: 'meta',
   return: 'enter',
   escape: 'esc',
   plus: '+',
-  mod: /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? 'meta' : 'ctrl'
+  mod: isApplePlatform() ? 'meta' : 'ctrl'
 }
 
 /**


### PR DESCRIPTION
Trying to use this library on a nuxt application using server side rendering throws an error when trying to access `navigator.platform`. This PR only check if `navigator` is defined before accessing to `navigator.platform`